### PR TITLE
Expose metric timestamp on initial query

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/mantle",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "description": "Mantle consumes and logs Sparkplug B data",
   "author": "Joy Automation",
   "license": "GPL-3.0-or-later",

--- a/synapse.ts
+++ b/synapse.ts
@@ -278,6 +278,19 @@ export function addHostToSchema(
           (parent as SparkplugMetricFlat & { templateInstance?: string })
             .templateInstance ?? null,
       }),
+      timestamp: t.field({
+        type: "Float",
+        nullable: true,
+        resolve: (parent) => {
+          if (parent.timestamp === null || parent.timestamp === undefined) {
+            return null;
+          }
+          if (Long.isLong(parent.timestamp)) {
+            return parent.timestamp.toNumber();
+          }
+          return parent.timestamp as number;
+        },
+      }),
     }),
   });
   SparkplugMetricPropertyRef.implement({


### PR DESCRIPTION
## Summary
- Add `timestamp` field to `SparkplugMetricRef` GraphQL type so initial queries return the last-known timestamp for each metric
- Fixes staleness indicators showing incorrect values on page load (previously required a subscription update to get any timestamp)

## Test plan
- [ ] Verify `groups` query returns `timestamp` on metrics
- [ ] Verify staleness dots show correct age on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)